### PR TITLE
Improves card dragging at the bottom of the playable area

### DIFF
--- a/src/player.html
+++ b/src/player.html
@@ -21,7 +21,9 @@
 		<!-- MAIN WIDGET SCRIPT -->
 		<script src="player.js"></script>
 	</head>
-	<body ng-app="SortItOutEngine" ng-controller="SortItOutEngineCtrl" ng-cloak ng-style="{'background-image': 'url(' + backgroundImage + ')'}">
+	<body id="app-body" ng-app="SortItOutEngine" ng-controller="SortItOutEngineCtrl" ng-cloak ng-style="{
+			'background-image': 'linear-gradient(rgba(0,0,0,0) 0%, rgba(0,0,0,0) 75%, rgba(0,0,0,0.33) 100%), url('+ backgroundImage + ')'
+		}">
 		<div id="content"
 			hm-panmove="panMove(standardizeEvent($event), false)"
 			hm-panend="mouseUp(standardizeEvent($event), false)"
@@ -175,7 +177,6 @@
 			</div>
 
 			<div id="dock-main" class="dock" tabindex="-1">
-				<div id="dock-main-background" class="dock" ng-click="hideFolderPreview()" tabindex="-1"></div>
 				<div class="folder"
 					ng-class="{opened: folderPreviewIndex == $index}"
 					ng-repeat="folder in folders"

--- a/src/player.scss
+++ b/src/player.scss
@@ -7,6 +7,8 @@ body {
 	background-position: center center;
 	height: 100vh;
 	font-family: "Lato";
+
+	overflow: hidden;
 }
 
 .screenreader-assist {
@@ -283,7 +285,7 @@ button.cancel-submit-button {
 .dock {
 	position: absolute;
 	height: 125px;
-	bottom: 0;
+	bottom: -125px;
 	left: 0;
 	right: 0;
 	display: flex;
@@ -294,6 +296,7 @@ button.cancel-submit-button {
 	}
 
 	.folder {
+		top: -125px;
 		height: 100%;
 		width: 150px;
 		position: relative;


### PR DESCRIPTION
Resolves #62, and by extension #55.

This was tricky since the arrangement of elements meant the desktop (which contains the draggable cards) and the dock (which contains the folders) occupy different stacking contexts, so z-index values were not shared. To function properly, the dock needed to remain "above" the desktop in z-height, but this caused it obfuscate cards behind it.

The solution I came up with was to move the dock element below the playable area, then reposition the folders by the inverse offset so they remain in their previous position. This allows the user to interact with folders normally, but the empty space around them is no longer blocking cards from being dragged.

This also applies `overflow:hidden` to the `body` element, which has the potential to resolve the behavior seen in #25 as well.