### PR TITLE
Resolves special character matching in score module

### DIFF
--- a/src/_score/score_module.php
+++ b/src/_score/score_module.php
@@ -30,7 +30,11 @@ class Score_Modules_SortItOut extends Score_Module
 		$answers = $this->questions[$log->item_id]->answers;
 		foreach($answers as $answer)
 		{
-			if ($log->text == $answer['text'])
+			// ensure string values are in parity. The answer value (coming from the qset) may include html entities.
+			$log_sanitized = html_entity_decode(strtolower(trim($log->text)));
+			$answer_sanitized = html_entity_decode(strtolower(trim($answer['text'])));
+
+			if ($log_sanitized == $answer_sanitized)
 			{
 				return $answer['value'];
 			}

--- a/src/scoreScreen.js
+++ b/src/scoreScreen.js
@@ -39,9 +39,9 @@ SortItOut.controller('SortItOutScoreCtrl', [
 			$scope.questionValue = 100 / qset.items.length
 
 			for (let item of qset.items) {
-				const folderName = item.answers[0].text
+				const folderName = sanitizeHelper.desanitize(item.answers[0].text)
 				if (item.options.image) {
-					imageMap[item.questions[0].text] = Materia.ScoreCore.getMediaUrl(item.options.image)
+					imageMap[sanitizeHelper.desanitize(item.questions[0].text)] = Materia.ScoreCore.getMediaUrl(item.options.image)
 				}
 				if (folderNames[folderName] == undefined) {
 					folderNames[folderName] = folders.length
@@ -56,8 +56,13 @@ SortItOut.controller('SortItOutScoreCtrl', [
 			}
 
 			for (let entry of scoreTable) {
-				const [text, userFolderName, correctFolderName] = entry.data
+				let [text, userFolderName, correctFolderName] = entry.data
 
+				text = sanitizeHelper.desanitize(text)
+				userFolderName = sanitizeHelper.desanitize(userFolderName)
+				correctFolderName = sanitizeHelper.desanitize(correctFolderName)
+
+				// ensure string values are properly decoded
 				const correctFolderIndex = folderNames[correctFolderName]
 				const userFolderIndex = folderNames[userFolderName]
 				const correct = userFolderName == correctFolderName
@@ -65,7 +70,7 @@ SortItOut.controller('SortItOutScoreCtrl', [
 				folders[userFolderIndex].placeCount++
 
 				const item = {
-					text: sanitizeHelper.desanitize(text),
+					text: text,
 					correct,
 					userFolderName,
 					image: imageMap[text] || false
@@ -78,7 +83,7 @@ SortItOut.controller('SortItOutScoreCtrl', [
 				} else {
 					folders[correctFolderIndex].items.push(item)
 					folders[userFolderIndex].extraItems.push({
-						text: sanitizeHelper.desanitize(text),
+						text: text,
 						image: imageMap[text] || false,
 						correctFolderName
 					})

--- a/src/scoreScreen.js
+++ b/src/scoreScreen.js
@@ -58,11 +58,11 @@ SortItOut.controller('SortItOutScoreCtrl', [
 			for (let entry of scoreTable) {
 				let [text, userFolderName, correctFolderName] = entry.data
 
+				// ensure string values are properly decoded
 				text = sanitizeHelper.desanitize(text)
 				userFolderName = sanitizeHelper.desanitize(userFolderName)
 				correctFolderName = sanitizeHelper.desanitize(correctFolderName)
 
-				// ensure string values are properly decoded
 				const correctFolderIndex = folderNames[correctFolderName]
 				const userFolderIndex = folderNames[userFolderName]
 				const correct = userFolderName == correctFolderName


### PR DESCRIPTION
Resolves #54.

For each "question" in Sort It Out, the score module compares the string value from the log (representing the folder name the card was placed into) with the string value of the correct folder name in the qset. However, the qset string may container encoded HTML entities while the log string does not. The score module now sanitizes both strings (flattening case, removing whitespace, and decoding HTML entities) before comparing them.

To test:
1. Create a new instance of Sort It Out that includes special characters in a folder name.
2. Play the instance.
3. Verify that scoring is correct and the score screen renders correctly.